### PR TITLE
adding version label to webhook

### DIFF
--- a/helm/cluster-api-core/templates/_resource.tpl
+++ b/helm/cluster-api-core/templates/_resource.tpl
@@ -31,5 +31,5 @@ giantswarm
 {{- end -}}
 
 {{- define "resource.app.version" -}}
-{{- .Chart.Version | trunc 47 | trimSuffix "-" -}}
+{{- .Chart.Version | trunc 12 | trimSuffix "-" -}}
 {{- end -}}

--- a/helm/cluster-api-core/templates/_resource.tpl
+++ b/helm/cluster-api-core/templates/_resource.tpl
@@ -31,5 +31,5 @@ giantswarm
 {{- end -}}
 
 {{- define "resource.app.version" -}}
-{{- .Chart.Version | replace "." "-"| trunc 12 | trimSuffix "-"| replace "-" "." -}}
+0.0.1
 {{- end -}}

--- a/helm/cluster-api-core/templates/_resource.tpl
+++ b/helm/cluster-api-core/templates/_resource.tpl
@@ -31,5 +31,5 @@ giantswarm
 {{- end -}}
 
 {{- define "resource.app.version" -}}
-{{- .Chart.Version | trunc 12 | trimSuffix "-" -}}
+{{- .Chart.Version | replace "." "-"| trunc 12 | trimSuffix "-"| replace "-" "." -}}
 {{- end -}}

--- a/helm/cluster-api-core/templates/_resource.tpl
+++ b/helm/cluster-api-core/templates/_resource.tpl
@@ -29,3 +29,7 @@ giantswarm
 {{- define "resource.webhook.name" -}}
 {{- include "resource.default.name" . -}}-webhook
 {{- end -}}
+
+{{- define "resource.app.version" -}}
+{{- .Chart.Version | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/cluster-api-core/templates/_resource.tpl
+++ b/helm/cluster-api-core/templates/_resource.tpl
@@ -31,5 +31,5 @@ giantswarm
 {{- end -}}
 
 {{- define "resource.app.version" -}}
-{{- .Chart.Version | trimSuffix "-" -}}
+{{- .Chart.Version | trunc 47 | trimSuffix "-" -}}
 {{- end -}}

--- a/helm/cluster-api-core/templates/controller-deployment.yaml
+++ b/helm/cluster-api-core/templates/controller-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:{{ .Values.ports.metrics }}
         - --feature-gates=MachinePool={{ .Values.featuregates.machinepool }},ClusterResourceSet={{ .Values.featuregates.clusterresourceset }}
-        - --watch-filter={{ .Chart.Version }}
+        - --watch-filter={{ include "resource.app.version" . }}
         command:
         - /manager
         image: "{{ .Values.images.controller.registry }}/{{ .Values.images.controller.name }}:{{ .Values.images.controller.tag }}"

--- a/helm/cluster-api-core/templates/controller-deployment.yaml
+++ b/helm/cluster-api-core/templates/controller-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:{{ .Values.ports.metrics }}
         - --feature-gates=MachinePool={{ .Values.featuregates.machinepool }},ClusterResourceSet={{ .Values.featuregates.clusterresourceset }}
-        - --watch-filter=0.0.1
+        - --watch-filter={{ .Chart.Version }}
         command:
         - /manager
         image: "{{ .Values.images.controller.registry }}/{{ .Values.images.controller.name }}:{{ .Values.images.controller.tag }}"

--- a/helm/cluster-api-core/templates/mutating-webhook.yaml
+++ b/helm/cluster-api-core/templates/mutating-webhook.yaml
@@ -18,6 +18,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.cluster.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -39,6 +42,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.machine.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -60,6 +66,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.machinedeployment.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -81,6 +90,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.machinehealthcheck.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -102,6 +114,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.machineset.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -123,6 +138,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.exp.machinepool.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - exp.cluster.x-k8s.io
@@ -144,6 +162,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: default.clusterresourceset.addons.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - addons.cluster.x-k8s.io

--- a/helm/cluster-api-core/templates/mutating-webhook.yaml
+++ b/helm/cluster-api-core/templates/mutating-webhook.yaml
@@ -20,7 +20,7 @@ webhooks:
   name: default.cluster.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -44,7 +44,7 @@ webhooks:
   name: default.machine.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -68,7 +68,7 @@ webhooks:
   name: default.machinedeployment.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -92,7 +92,7 @@ webhooks:
   name: default.machinehealthcheck.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -116,7 +116,7 @@ webhooks:
   name: default.machineset.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -140,7 +140,7 @@ webhooks:
   name: default.exp.machinepool.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - exp.cluster.x-k8s.io
@@ -164,7 +164,7 @@ webhooks:
   name: default.clusterresourceset.addons.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - addons.cluster.x-k8s.io

--- a/helm/cluster-api-core/templates/validating-webhook.yaml
+++ b/helm/cluster-api-core/templates/validating-webhook.yaml
@@ -20,7 +20,7 @@ webhooks:
   name: validation.cluster.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -44,7 +44,7 @@ webhooks:
   name: validation.machine.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -68,7 +68,7 @@ webhooks:
   name: validation.machinedeployment.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -92,7 +92,7 @@ webhooks:
   name: validation.machinehealthcheck.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -116,7 +116,7 @@ webhooks:
   name: validation.machineset.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -140,7 +140,7 @@ webhooks:
   name: validation.exp.machinepool.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - exp.cluster.x-k8s.io
@@ -164,7 +164,7 @@ webhooks:
   name: validation.clusterresourceset.addons.cluster.x-k8s.io
   objectSelector:
     matchLabels:
-      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
+      cluster.x-k8s.io/watch-filter: {{ include "resource.app.version" . }}
   rules:
   - apiGroups:
     - addons.cluster.x-k8s.io

--- a/helm/cluster-api-core/templates/validating-webhook.yaml
+++ b/helm/cluster-api-core/templates/validating-webhook.yaml
@@ -18,6 +18,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.cluster.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -39,6 +42,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.machine.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -60,6 +66,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.machinedeployment.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -81,6 +90,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.machinehealthcheck.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -102,6 +114,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.machineset.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - cluster.x-k8s.io
@@ -123,6 +138,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.exp.machinepool.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - exp.cluster.x-k8s.io
@@ -144,6 +162,9 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Equivalent
   name: validation.clusterresourceset.addons.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: {{ .Chart.Version }}
   rules:
   - apiGroups:
     - addons.cluster.x-k8s.io


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16003
We want the webhook to only watch resources that are reconciled by its respective controller, so we version it.