### PR TITLE
Only deploy crd conversion on unique app

### DIFF
--- a/helm/cluster-api-core/templates/_resource.tpl
+++ b/helm/cluster-api-core/templates/_resource.tpl
@@ -33,3 +33,7 @@ giantswarm
 {{- define "resource.app.version" -}}
 0.0.2
 {{- end -}}
+
+{{- define "resource.app.unique" -}}
+{{- if hasSuffix "-unique" .Release.Name }}true{{ else }}false{{ end }}
+{{- end -}}

--- a/helm/cluster-api-core/templates/controller-clusterrolebinding.yaml
+++ b/helm/cluster-api-core/templates/controller-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{ if eq (include "resource.app.unique" .) "false" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "resource.default.name" . }}
   namespace: {{ include "resource.default.namespace" . }}
+{{ end }}

--- a/helm/cluster-api-core/templates/controller-deployment.yaml
+++ b/helm/cluster-api-core/templates/controller-deployment.yaml
@@ -1,3 +1,4 @@
+{{ if eq (include "resource.app.unique" .) "false" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,3 +62,4 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+{{ end }}

--- a/helm/cluster-api-core/templates/controller-rbac.yaml
+++ b/helm/cluster-api-core/templates/controller-rbac.yaml
@@ -1,3 +1,4 @@
+{{ if eq (include "resource.app.unique" .) "false" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -204,3 +205,4 @@ rules:
   - patch
   - update
   - watch
+{{ end }}

--- a/helm/cluster-api-core/templates/controller-service.yaml
+++ b/helm/cluster-api-core/templates/controller-service.yaml
@@ -1,3 +1,4 @@
+{{ if eq (include "resource.app.unique" .) "false" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
     targetPort: https
   selector:
     {{- include "labels.selector" . | nindent 4 }}
+{{ end }}

--- a/helm/cluster-api-core/templates/controller-serviceaccount.yaml
+++ b/helm/cluster-api-core/templates/controller-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if eq (include "resource.app.unique" .) "false" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ include "resource.default.namespace" . }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+{{ end }}

--- a/helm/cluster-api-core/templates/mutating-webhook.yaml
+++ b/helm/cluster-api-core/templates/mutating-webhook.yaml
@@ -1,3 +1,4 @@
+{{ if eq (include "resource.app.unique" .) "false" }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -176,3 +177,4 @@ webhooks:
     resources:
     - clusterresourcesets
   sideEffects: None
+{{ end }}

--- a/helm/cluster-api-core/templates/validating-webhook.yaml
+++ b/helm/cluster-api-core/templates/validating-webhook.yaml
@@ -1,3 +1,4 @@
+{{ if eq (include "resource.app.unique" .) "false" }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -176,3 +177,4 @@ webhooks:
     resources:
     - clusterresourcesets
   sideEffects: None
+{{ end }}

--- a/helm/cluster-api-core/values.yaml
+++ b/helm/cluster-api-core/values.yaml
@@ -10,6 +10,8 @@ images:
     name: kubebuilder/kube-rbac-proxy
     tag: v0.8.0
 
+crdConvertOnly: true
+
 featuregates:
   machinepool: true
   clusterresourceset: true


### PR DESCRIPTION
When installed as a unique app, we would only like the conversion webhook deployment to be installed.

Towards https://github.com/giantswarm/giantswarm/issues/16382