### PR TITLE
Remove rbac proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove kube-rbac-proxy for the metrics endpoint.
+
+### Fixed
+
+- Fixed label selector for webhook and manager services.
+
 ## [0.3.14-gs2] - 2021-05-27
 
 ## [0.3.14-gs1] - 2021-05-12

--- a/helm/cluster-api-core/templates/controller-deployment.yaml
+++ b/helm/cluster-api-core/templates/controller-deployment.yaml
@@ -11,29 +11,18 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+      control-plane: controller-manager
   template:
     metadata:
       annotations:
         releaseRevision: {{ .Release.Revision | quote }}
       labels:
         {{- include "labels.common" . | nindent 8 }}
+        control-plane: controller-manager
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:{{ .Values.ports.proxy }}
-        - --upstream=http://127.0.0.1:{{ .Values.ports.metrics }}/
-        - --logtostderr=true
-        image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.images.proxy.name }}:{{ .Values.images.proxy.tag }}"
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: {{ .Values.ports.proxy }}
-          name: https
-          protocol: TCP
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-      - args:
-        - --metrics-addr=127.0.0.1:{{ .Values.ports.metrics }}
+        - --metrics-addr=0.0.0.0:{{ .Values.ports.metrics }}
         - --feature-gates=MachinePool={{ .Values.featuregates.machinepool }},ClusterResourceSet={{ .Values.featuregates.clusterresourceset }}
         - --watch-filter={{ .Values.watchfilter }}
         command:
@@ -48,6 +37,9 @@ spec:
         ports:
         - containerPort: {{ .Values.ports.healthz }}
           name: healthz
+          protocol: TCP
+        - containerPort: {{ .Values.ports.metrics }}
+          name: metrics
           protocol: TCP
         readinessProbe:
           httpGet:

--- a/helm/cluster-api-core/templates/controller-service.yaml
+++ b/helm/cluster-api-core/templates/controller-service.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     giantswarm.io/monitoring: "true"
+    giantswarm.io/monitoring-port: "{{ .Values.ports.metrics }}"
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ include "resource.default.name" . }}

--- a/helm/cluster-api-core/templates/controller-service.yaml
+++ b/helm/cluster-api-core/templates/controller-service.yaml
@@ -4,16 +4,17 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/scrape: "true"
-  labels:
     giantswarm.io/monitoring: "true"
+  labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ include "resource.default.name" . }}
   namespace: {{ include "resource.default.namespace" . }}
 spec:
   ports:
-  - name: https
-    port: {{ .Values.ports.proxy }}
-    targetPort: https
+  - name: metrics
+    port: {{ .Values.ports.metrics }}
+    targetPort: metrics
   selector:
     {{- include "labels.selector" . | nindent 4 }}
+    control-plane: controller-manager
 {{ end }}

--- a/helm/cluster-api-core/templates/webhook-deployment.yaml
+++ b/helm/cluster-api-core/templates/webhook-deployment.yaml
@@ -10,29 +10,18 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+      control-plane: webhook
   template:
     metadata:
       annotations:
         releaseRevision: {{ .Release.Revision | quote }}
       labels:
         {{- include "labels.common" . | nindent 8 }}
+        control-plane: webhook
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:{{ .Values.ports.proxy }}
-        - --upstream=http://127.0.0.1:{{ .Values.ports.metrics }}/
-        - --logtostderr=true
-        image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.images.proxy.name }}:{{ .Values.images.proxy.tag }}"
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: {{ .Values.ports.proxy }}
-          name: metrics
-          protocol: TCP
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-      - args:
-        - --metrics-addr=127.0.0.1:{{ .Values.ports.metrics }}
+        - --metrics-addr=0.0.0.0:{{ .Values.ports.metrics }}
         - --webhook-port={{ .Values.ports.webhook }}
         - --feature-gates=MachinePool={{ .Values.featuregates.machinepool }},ClusterResourceSet={{ .Values.featuregates.clusterresourceset }}
         command:

--- a/helm/cluster-api-core/templates/webhook-service.yaml
+++ b/helm/cluster-api-core/templates/webhook-service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  annotations:
+    giantswarm.io/monitoring: "true"
+    giantswarm.io/monitoring-port: "{{ .Values.ports.metrics }}"
   name: {{ include "resource.webhook.name" . }}
   namespace: {{ include "resource.default.namespace" . }}
 spec:
@@ -11,7 +14,8 @@ spec:
     port: {{ .Values.ports.webhook }}
     targetPort: webhook
   - name: metrics
-    port: {{ .Values.ports.proxy }}
+    port: {{ .Values.ports.metrics }}
     targetPort: metrics
   selector:
     {{- include "labels.selector" . | nindent 4 }}
+    control-plane: webhook

--- a/helm/cluster-api-core/values.yaml
+++ b/helm/cluster-api-core/values.yaml
@@ -4,9 +4,6 @@ images:
   controller:
     name: giantswarm/cluster-api-controller
     tag: bb90d2037f840c82ee2fd61a181699b94bbbb53e
-  proxy:
-    name: giantswarm/kube-rbac-proxy
-    tag: v0.8.0
 
 crdConvertOnly: true
 
@@ -15,7 +12,6 @@ featuregates:
   clusterresourceset: true
 
 ports:
-  proxy: 8443
   healthz: 9440
   metrics: 8080
   webhook: 9443


### PR DESCRIPTION
According to upstream direction (https://github.com/kubernetes-sigs/cluster-api/issues/4679) this PR removes the rbac proxy from the metrics endpoint.
We don't use it anywhere else and it's just better to not have it for conformity