### PR TITLE
Don't deploy using app collections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,16 +17,3 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      - architect/push-to-app-collection:
-          name: push-aws-app-collection
-          context: architect
-          app_name: "cluster-api-core"
-          app_collection_repo: "aws-app-collection"
-          requires:
-            - push-to-app-catalog
-          filters:
-            # Only do this when a new tag is created.
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Don't publish app to the app collection.
+
 ## [0.3.22-gs1] - 2021-08-02
 
 ### Changed


### PR DESCRIPTION
On our latest kaas sync we talked about using `Release` to deploy capi components, rather than using collections.

Currently, this app is pushed to the app collection whenever there is a new release. If we want to control its deployment with `Releases` we need to avoid publishing to the app collection.

On a next PR, I'll remove the app from the app collection.